### PR TITLE
chore(base): upgrade to UBI9, golang 1.22.7

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,8 +1,8 @@
-ARG builder_version=8.10
-ARG runner_version=8.10
-ARG goversion=go1.22.6
+ARG builder_version=9.4
+ARG runner_version=9.4
+ARG goversion=go1.22.7
 
-FROM registry.access.redhat.com/ubi8/ubi:$builder_version AS builder
+FROM registry.access.redhat.com/ubi9/ubi:$builder_version AS builder
 ARG goversion
 COPY . .
 RUN dnf install -y go \
@@ -10,6 +10,6 @@ RUN dnf install -y go \
     && ~/go/bin/$goversion download \
     && ~/go/bin/$goversion build -a -v -x .
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:$runner_version
+FROM registry.access.redhat.com/ubi9/ubi-minimal:$runner_version
 COPY --from=builder ./oauth-proxy /usr/bin/oauth-proxy
 ENTRYPOINT ["/usr/bin/oauth-proxy"]


### PR DESCRIPTION
Related to https://github.com/cryostatio/cryostat/issues/650
