### PR TITLE
fix(uid): set default container uid

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,7 @@
 ARG builder_version=8.10
 ARG runner_version=8.10
 ARG goversion=go1.22.6
+ARG user_id=1001
 
 FROM registry.access.redhat.com/ubi8/ubi:$builder_version AS builder
 ARG goversion
@@ -11,5 +12,7 @@ RUN dnf install -y go \
     && ~/go/bin/$goversion build -a -v -x .
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:$runner_version
+ARG user_id
 COPY --from=builder ./oauth-proxy /usr/bin/oauth-proxy
+USER $user_id
 ENTRYPOINT ["/usr/bin/oauth-proxy"]

--- a/build.bash
+++ b/build.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -xe
+
+DIR="$(dirname "$(readlink -f "$0")")"
+
+IMAGE_NAMESPACE="${IMAGE_NAMESPACE:-quay.io/cryostat}"
+IMAGE_NAME="${IMAGE_NAME:-openshift-oauth-proxy}"
+
+podman build -f "${DIR}/Containerfile" . -t "${IMAGE_NAMESPACE}/${IMAGE_NAME}:latest"
+
+for tag in $IMAGE_TAGS; do
+    podman tag "${IMAGE_NAMESPACE}/${IMAGE_NAME}:latest" "${IMAGE_NAMESPACE}/${IMAGE_NAME}:${tag}"
+done


### PR DESCRIPTION
Fixes #10
Related to https://github.com/cryostatio/cryostat-operator/issues/969

To test using the Cryostat Operator on OpenShift:
1. export OPENSHIFT_OAUTH_PROXY_IMG=quay.io/andrewazores/openshift-oauth-proxy:uid-1
2. Build and deploy Operator in `default` namespace
3. Create Cryostat CR in `default` namespace with that as the target namespace: `TARGET_NAMESPACES=$(oc project -q) make create_cryostat_cr`
4. Ensure that the Cryostat Deployment is created and Pod becomes Ready
5. Ensure that the auth-proxy container within the Pod is running the image above (built from this PR)
6. Ensure that the auth-proxy container is running normally and Cryostat can be accessed by logging in through the proxy as usual

Or to test using Cryostat Helm on OpenShift:
1. Switch to `default` project (`oc project default`)
2. Deploy with existing upstream images to reproduce the bug: `$ helm install cryostat --set authentication.openshift.enabled=true --set core.route.enabled=true ./charts/cryostat/`
3. `helm uninstall cryostat`
4. Deploy with this PR's auth-proxy rebuild: `$ helm install cryostat --set openshiftOauthProxy.image.repository=quay.io/andrewazores/openshift-oauth-proxy --set openshiftOauthProxy.image.tag=uid-1 --set authentication.openshift.enabled=true --set core.route.enabled=true ./charts/cryostat/`
5. Check OpenShift console to ensure that the Pod becomes ready, the container is running the expected image, etc.
6. Go to Cryostat Route and ensure that it's possible to log in and access Cryostat through the proxy